### PR TITLE
Upgrade the gradlew for gradle-plugin/ to 6.4.1

### DIFF
--- a/java/gradle-plugin/gradle/wrapper/gradle-wrapper.properties
+++ b/java/gradle-plugin/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.4.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This matches the version we use for lib/ and is the latest one that is
available.